### PR TITLE
Enable JSON mode for response output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "^17.3.0",
         "@angular/platform-browser-dynamic": "^17.3.0",
         "@angular/router": "^17.3.0",
-        "@google/generative-ai": "^0.8.0",
+        "@google/generative-ai": "^0.11.3",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.3"
@@ -2634,9 +2634,9 @@
       }
     },
     "node_modules/@google/generative-ai": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.8.0.tgz",
-      "integrity": "sha512-O55FgK1Jvl2JuJP1cnRHEAM8A4Lr3yKtjQrCn2QXOXVT+L5+o/nFQcx0/oIo3oq1Kq9TjjgewXyb9BBrK+Wd0A==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.11.3.tgz",
+      "integrity": "sha512-QtQ1hz6rcybbw35uxXlFF26KNnaTVr2oWwnmDkC1M35KdzN4tVc4wakgJp8uXbY9KDCNHksyp11DbFg0HPckZQ==",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -14124,9 +14124,9 @@
       "optional": true
     },
     "@google/generative-ai": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.8.0.tgz",
-      "integrity": "sha512-O55FgK1Jvl2JuJP1cnRHEAM8A4Lr3yKtjQrCn2QXOXVT+L5+o/nFQcx0/oIo3oq1Kq9TjjgewXyb9BBrK+Wd0A=="
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.11.3.tgz",
+      "integrity": "sha512-QtQ1hz6rcybbw35uxXlFF26KNnaTVr2oWwnmDkC1M35KdzN4tVc4wakgJp8uXbY9KDCNHksyp11DbFg0HPckZQ=="
     },
     "@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "^17.3.0",
     "@angular/platform-browser-dynamic": "^17.3.0",
     "@angular/router": "^17.3.0",
-    "@google/generative-ai": "^0.8.0",
+    "@google/generative-ai": "^0.11.3",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -87,13 +87,13 @@ export class AppComponent {
     const model = genAI.getGenerativeModel({
       model: 'gemini-1.5-pro-latest'
     });
-    model.generationConfig.responseMimeType = 'application/json'
+    model.generationConfig.responseMimeType = 'application/json';
     
     this.loading = true;
 
     try {
       const result = await model.generateContent(prompt);
-      const response = await result.response;
+      const response = result.response;
       const text = response.text();
       const tune = JSON.parse(text);
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -85,8 +85,9 @@ export class AppComponent {
     const genAI = new GoogleGenerativeAI(this.apiKey().nativeElement.value);
 
     const model = genAI.getGenerativeModel({
-      model: 'gemini-pro'
+      model: 'gemini-1.5-pro-latest'
     });
+    model.generationConfig.responseMimeType = 'application/json'
     
     this.loading = true;
 
@@ -94,8 +95,7 @@ export class AppComponent {
       const result = await model.generateContent(prompt);
       const response = await result.response;
       const text = response.text();
-
-      const tune = JSON.parse(text.replace(/```json/i, '').replace(/```js/i, '').replace(/```javascript/i, '').replace('```', ''));
+      const tune = JSON.parse(text);
 
       this.keyboard().playMelody(tune);
     } catch (e: unknown) {


### PR DESCRIPTION
- Enable JSON mode by setting output MIME type to `application/json`
- Use JSON mode compatible model `gemini-1.5-pro-latest`
- Update @google/generative-ai to supporting version 0.11.3
- Remove text-based preprocessing of response